### PR TITLE
Correct the tests to make them not drop the connection

### DIFF
--- a/crates/xwt-tests/src/tests.rs
+++ b/crates/xwt-tests/src/tests.rs
@@ -29,11 +29,11 @@ where
     Endpoint::Connecting: std::fmt::Debug,
     EndpointConnectConnectionFor<Endpoint>: xwt_core::OpenBiStream + std::fmt::Debug,
 {
-    let connection = crate::utils::connect(endpoint, url)
+    let connection = crate::utils::connect(&endpoint, url)
         .await
         .map_err(EchoError::Connect)?;
 
-    let (mut send_stream, mut recv_stream) = crate::utils::open_bi(connection)
+    let (mut send_stream, mut recv_stream) = crate::utils::open_bi(&connection)
         .await
         .map_err(EchoError::Open)?;
 
@@ -115,11 +115,11 @@ where
     SendStreamFor<EndpointConnectConnectionFor<Endpoint>>: xwt_core::WriteChunk<WriteChunk>,
     RecvStreamFor<EndpointConnectConnectionFor<Endpoint>>: xwt_core::ReadChunk<ReadChunk>,
 {
-    let connection = crate::utils::connect(endpoint, url)
+    let connection = crate::utils::connect(&endpoint, url)
         .await
         .map_err(EchoChunksError::Connect)?;
 
-    let (mut send_stream, mut recv_stream) = crate::utils::open_bi(connection)
+    let (mut send_stream, mut recv_stream) = crate::utils::open_bi(&connection)
         .await
         .map_err(EchoChunksError::Open)?;
 
@@ -173,7 +173,7 @@ where
     EndpointConnectConnectionFor<Endpoint>: xwt_core::datagram::Datagrams + std::fmt::Debug,
     ReceiveDatagramFor<EndpointConnectConnectionFor<Endpoint>>: std::fmt::Debug,
 {
-    let connection = crate::utils::connect(endpoint, url)
+    let connection = crate::utils::connect(&endpoint, url)
         .await
         .map_err(EchoDatagrmsError::Connect)?;
 

--- a/crates/xwt-tests/src/tests/read_small_buf.rs
+++ b/crates/xwt-tests/src/tests/read_small_buf.rs
@@ -27,11 +27,11 @@ where
     Endpoint::Connecting: std::fmt::Debug,
     EndpointConnectConnectionFor<Endpoint>: xwt_core::OpenBiStream + std::fmt::Debug,
 {
-    let connection = crate::utils::connect(endpoint, url)
+    let connection = crate::utils::connect(&endpoint, url)
         .await
         .map_err(Error::Connect)?;
 
-    let (mut send_stream, mut recv_stream) = crate::utils::open_bi(connection)
+    let (mut send_stream, mut recv_stream) = crate::utils::open_bi(&connection)
         .await
         .map_err(Error::Open)?;
 

--- a/crates/xwt-tests/src/utils.rs
+++ b/crates/xwt-tests/src/utils.rs
@@ -1,7 +1,7 @@
 use xwt_core::prelude::*;
 
 pub async fn connect<Endpoint>(
-    endpoint: Endpoint,
+    endpoint: &Endpoint,
     url: &str,
 ) -> Result<EndpointConnectConnectionFor<Endpoint>, xwt_error::Connect<Endpoint>>
 where
@@ -41,7 +41,7 @@ where
 }
 
 pub async fn open_bi<Connection>(
-    connection: Connection,
+    connection: &Connection,
 ) -> Result<BiStreamsFor<Connection>, xwt_error::OpenBi<Connection>>
 where
     Connection: xwt_core::OpenBiStream,
@@ -59,7 +59,7 @@ where
 }
 
 pub async fn open_uni<Connection>(
-    connection: Connection,
+    connection: &Connection,
 ) -> Result<SendUniStreamFor<Connection>, xwt_error::OpenUni<Connection>>
 where
     Connection: xwt_core::OpenUniStream,


### PR DESCRIPTION
The investigation of this actually uncovered bugs! Specifically, at the `web-sys` when we drop the connection we should close the transport. See #80.

Fixes #71.