### PR TITLE
Switch to BYOB reader for datagrams to avoid allocations at the xwt-web-sys

### DIFF
--- a/crates/xwt-web-sys/Cargo.toml
+++ b/crates/xwt-web-sys/Cargo.toml
@@ -19,7 +19,7 @@ xwt-core = { version = "0.2", path = "../xwt-core", default-features = false }
 web-sys-async-io = { version = "0.2.5", path = "../web-sys-async-io" }
 web-sys-stream-utils = { version = "0.2", path = "../web-sys-stream-utils" }
 
-tokio = { version = "1", default-features = false, features = [] }
+tokio = { version = "1", default-features = false, features = ["sync"] }
 wasm-bindgen-futures = { version = "0.4" }
 wasm-bindgen = { version = "0.2" }
 js-sys = "0.3"
@@ -30,6 +30,7 @@ web-sys = { version = "0.3", features = [
   "WebTransportSendStream",
   "WebTransportReceiveStream",
   "ReadableStreamDefaultReader",
+  "ReadableStreamByobReader",
   "WritableStreamDefaultWriter",
   "WebTransportDatagramDuplexStream",
 ] }

--- a/crates/xwt-web-sys/src/error.rs
+++ b/crates/xwt-web-sys/src/error.rs
@@ -18,3 +18,9 @@ impl From<wasm_bindgen::JsValue> for Error {
         Self(value)
     }
 }
+
+impl From<wasm_bindgen::JsError> for Error {
+    fn from(value: wasm_bindgen::JsError) -> Self {
+        wasm_bindgen::JsValue::from(value).into()
+    }
+}

--- a/crates/xwt-web-sys/src/lib.rs
+++ b/crates/xwt-web-sys/src/lib.rs
@@ -301,7 +301,7 @@ impl xwt_core::datagram::Receive for Connection {
         let maybe_buffer =
             web_sys_stream_utils::read_byob(&self.datagram_readable_stream_reader, buffer).await?;
         let Some(buffer) = maybe_buffer else {
-            return Err(Error("unexpected stream termination".into()));
+            return Err(wasm_bindgen::JsError::new("unexpected stream termination").into());
         };
 
         let data = buffer.to_vec();


### PR DESCRIPTION
Closes #33.