### PR TITLE
Drop the async-trait crate and use raw rust async traits at xwt-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,17 +63,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1789,9 +1778,6 @@ dependencies = [
 [[package]]
 name = "xwt-core"
 version = "0.2.2"
-dependencies = [
- "async-trait",
-]
 
 [[package]]
 name = "xwt-error"

--- a/crates/xwt-core/Cargo.toml
+++ b/crates/xwt-core/Cargo.toml
@@ -11,4 +11,10 @@ Write once, run anywhere.
 repository = "https://github.com/MOZGIII/xwt"
 
 [dependencies]
-async-trait = "0.1"
+
+[features]
+default = ["std"]
+
+alloc = []
+error-in-core = []
+std = ["alloc"]

--- a/crates/xwt-core/src/datagram.rs
+++ b/crates/xwt-core/src/datagram.rs
@@ -1,30 +1,32 @@
-use async_trait::async_trait;
+use core::future::Future;
 
-use crate::utils::maybe;
+use crate::utils::{maybe, Error};
 
-#[cfg_attr(not(target_family = "wasm"), async_trait)]
-#[cfg_attr(target_family = "wasm", async_trait(?Send))]
 pub trait Receive: maybe::Send {
     type Datagram: maybe::Send + AsRef<[u8]>;
-    type Error: std::error::Error + maybe::Send + maybe::Sync + 'static;
+    type Error: Error + maybe::Send + maybe::Sync + 'static;
 
-    async fn receive_datagram(&self) -> Result<Self::Datagram, Self::Error>;
+    fn receive_datagram(
+        &self,
+    ) -> impl Future<Output = Result<Self::Datagram, Self::Error>> + maybe::Send;
 }
 
-#[cfg_attr(not(target_family = "wasm"), async_trait)]
-#[cfg_attr(target_family = "wasm", async_trait(?Send))]
 pub trait ReceiveInto: maybe::Send {
-    type Error: std::error::Error + maybe::Send + maybe::Sync + 'static;
+    type Error: Error + maybe::Send + maybe::Sync + 'static;
 
-    async fn receive_datagram_into(&self, buf: &mut [u8]) -> Result<usize, Self::Error>;
+    fn receive_datagram_into(
+        &self,
+        buf: &mut [u8],
+    ) -> impl Future<Output = Result<usize, Self::Error>> + maybe::Send;
 }
 
-#[cfg_attr(not(target_family = "wasm"), async_trait)]
-#[cfg_attr(target_family = "wasm", async_trait(?Send))]
 pub trait Send: maybe::Send {
-    type Error: std::error::Error + maybe::Send + maybe::Sync + 'static;
+    type Error: Error + maybe::Send + maybe::Sync + 'static;
 
-    async fn send_datagram<D>(&self, payload: D) -> Result<(), Self::Error>
+    fn send_datagram<D>(
+        &self,
+        payload: D,
+    ) -> impl Future<Output = Result<(), Self::Error>> + maybe::Send
     where
         D: maybe::Send + AsRef<[u8]>;
 }

--- a/crates/xwt-core/src/lib.rs
+++ b/crates/xwt-core/src/lib.rs
@@ -5,6 +5,13 @@
 //! flexibility at the type level.
 
 #![allow(missing_docs, clippy::missing_docs_in_private_items)]
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 pub mod datagram;
 pub mod datagram_utils;
@@ -16,9 +23,10 @@ pub mod traits;
 pub mod utils {
     pub mod dummy;
     pub mod maybe;
-}
 
-pub use async_trait::async_trait;
+    mod error;
+    pub use error::Error;
+}
 
 pub use io::*;
 pub use traits::*;

--- a/crates/xwt-core/src/utils/dummy.rs
+++ b/crates/xwt-core/src/utils/dummy.rs
@@ -1,5 +1,3 @@
-use async_trait::async_trait;
-
 use crate::Streams;
 
 use super::maybe;
@@ -7,14 +5,12 @@ use super::maybe;
 #[derive(Debug)]
 pub struct Connecting<T>(pub T);
 
-#[cfg_attr(not(target_family = "wasm"), async_trait)]
-#[cfg_attr(target_family = "wasm", async_trait(?Send))]
 impl<T> crate::traits::Connecting for Connecting<T>
 where
     T: maybe::Send,
 {
     type Connection = T;
-    type Error = std::convert::Infallible;
+    type Error = core::convert::Infallible;
 
     async fn wait_connect(self) -> Result<Self::Connection, Self::Error> {
         Ok(self.0)
@@ -24,14 +20,12 @@ where
 #[derive(Debug)]
 pub struct OpeningUniStream<T: Streams>(pub T::SendStream);
 
-#[cfg_attr(not(target_family = "wasm"), async_trait)]
-#[cfg_attr(target_family = "wasm", async_trait(?Send))]
 impl<T> crate::traits::OpeningUniStream for OpeningUniStream<T>
 where
     T: Streams,
 {
     type Streams = T;
-    type Error = std::convert::Infallible;
+    type Error = core::convert::Infallible;
 
     async fn wait_uni(self) -> Result<<T as Streams>::SendStream, Self::Error> {
         Ok(self.0)
@@ -41,14 +35,12 @@ where
 #[derive(Debug)]
 pub struct OpeningBiStream<T: Streams>(pub (T::SendStream, T::RecvStream));
 
-#[cfg_attr(not(target_family = "wasm"), async_trait)]
-#[cfg_attr(target_family = "wasm", async_trait(?Send))]
 impl<T> crate::traits::OpeningBiStream for OpeningBiStream<T>
 where
     T: Streams,
 {
     type Streams = T;
-    type Error = std::convert::Infallible;
+    type Error = core::convert::Infallible;
 
     async fn wait_bi(self) -> Result<crate::traits::BiStreamsFor<T>, Self::Error> {
         Ok(self.0)

--- a/crates/xwt-core/src/utils/error.rs
+++ b/crates/xwt-core/src/utils/error.rs
@@ -1,0 +1,11 @@
+#[cfg(feature = "std")]
+pub use std::error::Error;
+
+#[cfg(all(not(feature = "std"), feature = "error-in-core"))]
+pub use core::error::Error;
+
+#[cfg(all(not(feature = "std"), not(feature = "error-in-core")))]
+pub trait Error: core::fmt::Debug + core::fmt::Display {}
+
+#[cfg(all(not(feature = "std"), not(feature = "error-in-core")))]
+impl<T: core::fmt::Debug + core::fmt::Display> Error for T {}

--- a/crates/xwt-core/src/utils/maybe.rs
+++ b/crates/xwt-core/src/utils/maybe.rs
@@ -1,8 +1,8 @@
 #[cfg(not(target_family = "wasm"))]
-pub trait Send: std::marker::Send {}
+pub trait Send: core::marker::Send {}
 
 #[cfg(not(target_family = "wasm"))]
-impl<T> self::Send for T where T: std::marker::Send {}
+impl<T> self::Send for T where T: core::marker::Send {}
 
 #[cfg(target_family = "wasm")]
 pub trait Send {}
@@ -11,10 +11,10 @@ pub trait Send {}
 impl<T> self::Send for T {}
 
 #[cfg(not(target_family = "wasm"))]
-pub trait Sync: std::marker::Sync {}
+pub trait Sync: core::marker::Sync {}
 
 #[cfg(not(target_family = "wasm"))]
-impl<T> self::Sync for T where T: std::marker::Sync {}
+impl<T> self::Sync for T where T: core::marker::Sync {}
 
 #[cfg(target_family = "wasm")]
 pub trait Sync {}

--- a/crates/xwt-web-sys/src/lib.rs
+++ b/crates/xwt-web-sys/src/lib.rs
@@ -11,7 +11,6 @@
 use std::rc::Rc;
 
 use wasm_bindgen::JsError;
-use xwt_core::async_trait;
 
 mod error;
 mod options;
@@ -29,7 +28,6 @@ pub struct Endpoint {
     pub options: sys::WebTransportOptions,
 }
 
-#[async_trait(?Send)]
 impl xwt_core::traits::EndpointConnect for Endpoint {
     type Error = Error;
     type Connecting = Connecting;
@@ -51,7 +49,6 @@ pub struct Connecting {
     pub ready: js_sys::Promise,
 }
 
-#[async_trait(?Send)]
 impl xwt_core::Connecting for Connecting {
     type Connection = Connection;
     type Error = Error;
@@ -171,7 +168,6 @@ fn wrap_bi_stream(
     (send_stream, recv_stream)
 }
 
-#[async_trait(?Send)]
 impl xwt_core::traits::OpenBiStream for Connection {
     type Opening = xwt_core::utils::dummy::OpeningBiStream<Connection>;
 
@@ -187,7 +183,6 @@ impl xwt_core::traits::OpenBiStream for Connection {
     }
 }
 
-#[async_trait(?Send)]
 impl xwt_core::traits::AcceptBiStream for Connection {
     type Error = Error;
 
@@ -206,7 +201,6 @@ impl xwt_core::traits::AcceptBiStream for Connection {
     }
 }
 
-#[async_trait(?Send)]
 impl xwt_core::traits::OpenUniStream for Connection {
     type Opening = xwt_core::utils::dummy::OpeningUniStream<Connection>;
     type Error = Error;
@@ -221,7 +215,6 @@ impl xwt_core::traits::OpenUniStream for Connection {
     }
 }
 
-#[async_trait(?Send)]
 impl xwt_core::traits::AcceptUniStream for Connection {
     type Error = Error;
 
@@ -274,7 +267,6 @@ impl tokio::io::AsyncRead for RecvStream {
     }
 }
 
-#[async_trait(?Send)]
 impl xwt_core::io::Write for SendStream {
     type Error = Error;
 
@@ -284,7 +276,6 @@ impl xwt_core::io::Write for SendStream {
     }
 }
 
-#[async_trait(?Send)]
 impl xwt_core::io::Read for RecvStream {
     type Error = Error;
 
@@ -350,7 +341,6 @@ impl Connection {
     }
 }
 
-#[async_trait(?Send)]
 impl xwt_core::datagram::Receive for Connection {
     type Datagram = Vec<u8>;
     type Error = Error;
@@ -360,7 +350,6 @@ impl xwt_core::datagram::Receive for Connection {
     }
 }
 
-#[async_trait(?Send)]
 impl xwt_core::datagram::ReceiveInto for Connection {
     type Error = Error;
 
@@ -374,7 +363,6 @@ impl xwt_core::datagram::ReceiveInto for Connection {
     }
 }
 
-#[async_trait(?Send)]
 impl xwt_core::datagram::Send for Connection {
     type Error = Error;
 

--- a/crates/xwt-wtransport/src/lib.rs
+++ b/crates/xwt-wtransport/src/lib.rs
@@ -8,13 +8,10 @@
 )]
 #![cfg(not(target_family = "wasm"))]
 
-use xwt_core::async_trait;
-
 mod types;
 
 pub use self::types::*;
 
-#[async_trait]
 impl xwt_core::traits::EndpointConnect for Endpoint<wtransport::endpoint::endpoint_side::Client> {
     type Connecting = xwt_core::utils::dummy::Connecting<Connection>;
     type Error = wtransport::error::ConnectingError;
@@ -25,7 +22,6 @@ impl xwt_core::traits::EndpointConnect for Endpoint<wtransport::endpoint::endpoi
     }
 }
 
-#[async_trait]
 impl xwt_core::traits::EndpointAccept for Endpoint<wtransport::endpoint::endpoint_side::Server> {
     type Accepting = IncomingSession;
     type Error = std::convert::Infallible;
@@ -37,7 +33,6 @@ impl xwt_core::traits::EndpointAccept for Endpoint<wtransport::endpoint::endpoin
     }
 }
 
-#[async_trait]
 impl xwt_core::traits::Accepting for IncomingSession {
     type Request = SessionRequest;
     type Error = wtransport::error::ConnectionError;
@@ -47,7 +42,6 @@ impl xwt_core::traits::Accepting for IncomingSession {
     }
 }
 
-#[async_trait]
 impl xwt_core::traits::Request for SessionRequest {
     type Connection = Connection;
     type OkError = wtransport::error::ConnectionError;
@@ -80,7 +74,6 @@ fn map_streams(
     (SendStream(send), RecvStream(recv))
 }
 
-#[async_trait]
 impl xwt_core::traits::OpeningBiStream for OpeningBiStream {
     type Streams = Connection;
     type Error = wtransport::error::StreamOpeningError;
@@ -90,7 +83,6 @@ impl xwt_core::traits::OpeningBiStream for OpeningBiStream {
     }
 }
 
-#[async_trait]
 impl xwt_core::traits::OpenBiStream for Connection {
     type Opening = OpeningBiStream;
     type Error = wtransport::error::ConnectionError;
@@ -100,7 +92,6 @@ impl xwt_core::traits::OpenBiStream for Connection {
     }
 }
 
-#[async_trait]
 impl xwt_core::traits::AcceptBiStream for Connection {
     type Error = wtransport::error::ConnectionError;
 
@@ -109,7 +100,6 @@ impl xwt_core::traits::AcceptBiStream for Connection {
     }
 }
 
-#[async_trait]
 impl xwt_core::traits::OpeningUniStream for OpeningUniStream {
     type Streams = Connection;
     type Error = wtransport::error::StreamOpeningError;
@@ -121,7 +111,6 @@ impl xwt_core::traits::OpeningUniStream for OpeningUniStream {
     }
 }
 
-#[async_trait]
 impl xwt_core::traits::OpenUniStream for Connection {
     type Opening = OpeningUniStream;
     type Error = wtransport::error::ConnectionError;
@@ -131,7 +120,6 @@ impl xwt_core::traits::OpenUniStream for Connection {
     }
 }
 
-#[async_trait]
 impl xwt_core::traits::AcceptUniStream for Connection {
     type Error = wtransport::error::ConnectionError;
 
@@ -140,7 +128,6 @@ impl xwt_core::traits::AcceptUniStream for Connection {
     }
 }
 
-#[async_trait]
 impl xwt_core::io::Read for RecvStream {
     type Error = wtransport::error::StreamReadError;
 
@@ -149,7 +136,6 @@ impl xwt_core::io::Read for RecvStream {
     }
 }
 
-#[async_trait]
 impl xwt_core::io::Write for SendStream {
     type Error = wtransport::error::StreamWriteError;
 
@@ -158,16 +144,14 @@ impl xwt_core::io::Write for SendStream {
     }
 }
 
-#[async_trait]
 impl xwt_core::io::WriteChunk<xwt_core::io::chunk::U8> for SendStream {
     type Error = wtransport::error::StreamWriteError;
 
-    async fn write_chunk(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+    async fn write_chunk<'a>(&'a mut self, buf: &'a [u8]) -> Result<(), Self::Error> {
         self.0.write_all(buf).await
     }
 }
 
-#[async_trait]
 impl xwt_core::datagram::Receive for Connection {
     type Datagram = Datagram;
     type Error = wtransport::error::ConnectionError;
@@ -183,7 +167,6 @@ impl AsRef<[u8]> for Datagram {
     }
 }
 
-#[async_trait]
 impl xwt_core::datagram::ReceiveInto for Connection {
     type Error = wtransport::error::ConnectionError;
 
@@ -195,7 +178,6 @@ impl xwt_core::datagram::ReceiveInto for Connection {
     }
 }
 
-#[async_trait]
 impl xwt_core::datagram::Send for Connection {
     type Error = wtransport::error::SendDatagramError;
 


### PR DESCRIPTION
Also, add `no_std` support to the xwt-core crate