### PR TITLE
Max datagram size API

### DIFF
--- a/crates/xwt-core/src/lib.rs
+++ b/crates/xwt-core/src/lib.rs
@@ -36,7 +36,9 @@ pub mod prelude {
     pub use crate::endpoint::accept::{Accept as _, Accepting as _, Request as _};
     pub use crate::endpoint::connect::{Connect as _, Connecting as _};
     pub use crate::session::base::{DatagramOps as _, StreamOps as _};
-    pub use crate::session::datagram::{Receive as _, ReceiveInto as _, Send as _};
+    pub use crate::session::datagram::{
+        MaxDatagramSize as _, Receive as _, ReceiveInto as _, Send as _,
+    };
     pub use crate::session::stream::{
         AcceptBi as _, AcceptUni as _, OpenBi as _, OpenUni as _, OpeningBi as _, OpeningUni as _,
     };

--- a/crates/xwt-core/src/lib.rs
+++ b/crates/xwt-core/src/lib.rs
@@ -36,9 +36,7 @@ pub mod prelude {
     pub use crate::endpoint::accept::{Accept as _, Accepting as _, Request as _};
     pub use crate::endpoint::connect::{Connect as _, Connecting as _};
     pub use crate::session::base::{DatagramOps as _, StreamOps as _};
-    pub use crate::session::datagram::{
-        MaxDatagramSize as _, Receive as _, ReceiveInto as _, Send as _,
-    };
+    pub use crate::session::datagram::{MaxSize as _, Receive as _, ReceiveInto as _, Send as _};
     pub use crate::session::stream::{
         AcceptBi as _, AcceptUni as _, OpenBi as _, OpenUni as _, OpeningBi as _, OpeningUni as _,
     };

--- a/crates/xwt-core/src/session/base.rs
+++ b/crates/xwt-core/src/session/base.rs
@@ -35,15 +35,11 @@ impl<T> StreamOps for T where
 ///
 /// Also, consider depending on the individual datagram APIs directly.
 pub trait DatagramOps:
-    maybe::Send + datagram::MaxDatagramSize + datagram::Send + datagram::Receive + datagram::ReceiveInto
+    maybe::Send + datagram::MaxSize + datagram::Send + datagram::Receive + datagram::ReceiveInto
 {
 }
 
 impl<T> DatagramOps for T where
-    T: maybe::Send
-        + datagram::MaxDatagramSize
-        + datagram::Send
-        + datagram::Receive
-        + datagram::ReceiveInto
+    T: maybe::Send + datagram::MaxSize + datagram::Send + datagram::Receive + datagram::ReceiveInto
 {
 }

--- a/crates/xwt-core/src/session/base.rs
+++ b/crates/xwt-core/src/session/base.rs
@@ -35,11 +35,15 @@ impl<T> StreamOps for T where
 ///
 /// Also, consider depending on the individual datagram APIs directly.
 pub trait DatagramOps:
-    maybe::Send + datagram::Send + datagram::Receive + datagram::ReceiveInto
+    maybe::Send + datagram::MaxDatagramSize + datagram::Send + datagram::Receive + datagram::ReceiveInto
 {
 }
 
 impl<T> DatagramOps for T where
-    T: maybe::Send + datagram::Send + datagram::Receive + datagram::ReceiveInto
+    T: maybe::Send
+        + datagram::MaxDatagramSize
+        + datagram::Send
+        + datagram::Receive
+        + datagram::ReceiveInto
 {
 }

--- a/crates/xwt-core/src/session/datagram.rs
+++ b/crates/xwt-core/src/session/datagram.rs
@@ -4,6 +4,16 @@ use core::future::Future;
 
 use crate::utils::{maybe, Error};
 
+pub trait MaxDatagramSize: maybe::Send {
+    /// Gets the maximum byte length that a user-sent datagram is allowed to be.
+    ///
+    /// This has no relation to how big incoming datagrams may be.
+    ///
+    /// If this returns [`None`], this session does not support sending
+    /// datagrams.
+    fn max_datagram_size(&self) -> Option<usize>;
+}
+
 pub trait Receive: maybe::Send {
     type Datagram: maybe::Send + AsRef<[u8]>;
     type Error: Error + maybe::Send + maybe::Sync + 'static;

--- a/crates/xwt-core/src/session/datagram.rs
+++ b/crates/xwt-core/src/session/datagram.rs
@@ -4,7 +4,7 @@ use core::future::Future;
 
 use crate::utils::{maybe, Error};
 
-pub trait MaxDatagramSize: maybe::Send {
+pub trait MaxSize: maybe::Send {
     /// Gets the maximum byte length that a user-sent datagram is allowed to be.
     ///
     /// This has no relation to how big incoming datagrams may be.

--- a/crates/xwt-tests/src/tests/datagrams.rs
+++ b/crates/xwt-tests/src/tests/datagrams.rs
@@ -1,5 +1,7 @@
 use xwt_core::prelude::*;
 
+const MIN_DATAGRAM_SIZE: usize = 1024;
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error<Endpoint>
 where
@@ -11,6 +13,10 @@ where
 {
     #[error("connect: {0}")]
     Connect(#[source] xwt_error::Connect<Endpoint>),
+    #[error("datagrams not supported")]
+    DatagramsNotSupported,
+    #[error("max datagram size is smaller than minimum - {size} / {MIN_DATAGRAM_SIZE}")]
+    MaxDatagramSizeTooSmall { size: usize },
     #[error("send: {0}")]
     Send(#[source] SendErrorFor<ConnectSessionFor<Endpoint>>),
     #[error("recv: {0}")]
@@ -23,13 +29,25 @@ pub async fn run<Endpoint>(endpoint: Endpoint, url: &str) -> Result<(), Error<En
 where
     Endpoint: xwt_core::endpoint::Connect + std::fmt::Debug,
     Endpoint::Connecting: std::fmt::Debug,
-    ConnectSessionFor<Endpoint>:
-        xwt_core::session::datagram::Send + xwt_core::session::datagram::Receive + std::fmt::Debug,
+    ConnectSessionFor<Endpoint>: xwt_core::session::datagram::MaxDatagramSize
+        + xwt_core::session::datagram::Send
+        + xwt_core::session::datagram::Receive
+        + std::fmt::Debug,
     ReceiveDatagramFor<ConnectSessionFor<Endpoint>>: std::fmt::Debug,
 {
     let session = crate::utils::connect(&endpoint, url)
         .await
         .map_err(Error::Connect)?;
+
+    let max_datagram_size = session
+        .max_datagram_size()
+        .ok_or(Error::DatagramsNotSupported)?;
+
+    if max_datagram_size < MIN_DATAGRAM_SIZE {
+        return Err(Error::MaxDatagramSizeTooSmall {
+            size: max_datagram_size,
+        });
+    }
 
     session
         .send_datagram(&b"hello"[..])

--- a/crates/xwt-tests/src/tests/datagrams.rs
+++ b/crates/xwt-tests/src/tests/datagrams.rs
@@ -29,7 +29,7 @@ pub async fn run<Endpoint>(endpoint: Endpoint, url: &str) -> Result<(), Error<En
 where
     Endpoint: xwt_core::endpoint::Connect + std::fmt::Debug,
     Endpoint::Connecting: std::fmt::Debug,
-    ConnectSessionFor<Endpoint>: xwt_core::session::datagram::MaxDatagramSize
+    ConnectSessionFor<Endpoint>: xwt_core::session::datagram::MaxSize
         + xwt_core::session::datagram::Send
         + xwt_core::session::datagram::Receive
         + std::fmt::Debug,

--- a/crates/xwt-web-sys/src/lib.rs
+++ b/crates/xwt-web-sys/src/lib.rs
@@ -347,7 +347,7 @@ impl Session {
     }
 }
 
-impl xwt_core::session::datagram::MaxDatagramSize for Session {
+impl xwt_core::session::datagram::MaxSize for Session {
     fn max_datagram_size(&self) -> Option<usize> {
         let max_datagram_size = self.transport.datagrams().max_datagram_size();
         Some(usize::try_from(max_datagram_size).expect("u32 should fit in a usize on WASM"))

--- a/crates/xwt-web-sys/src/lib.rs
+++ b/crates/xwt-web-sys/src/lib.rs
@@ -350,7 +350,7 @@ impl Session {
 impl xwt_core::session::datagram::MaxSize for Session {
     fn max_datagram_size(&self) -> Option<usize> {
         let max_datagram_size = self.transport.datagrams().max_datagram_size();
-        Some(usize::try_from(max_datagram_size).expect("u32 should fit in a usize on WASM"))
+        Some(usize::try_from(max_datagram_size).unwrap()) // u32 should fit in a usize on WASM
     }
 }
 

--- a/crates/xwt-web-sys/src/lib.rs
+++ b/crates/xwt-web-sys/src/lib.rs
@@ -347,6 +347,13 @@ impl Session {
     }
 }
 
+impl xwt_core::session::datagram::MaxDatagramSize for Session {
+    fn max_datagram_size(&self) -> Option<usize> {
+        let max_datagram_size = self.transport.datagrams().max_datagram_size();
+        Some(usize::try_from(max_datagram_size).expect("u32 should fit in a usize on WASM"))
+    }
+}
+
 impl xwt_core::session::datagram::Receive for Session {
     type Datagram = Vec<u8>;
     type Error = Error;

--- a/crates/xwt-wtransport/src/lib.rs
+++ b/crates/xwt-wtransport/src/lib.rs
@@ -161,6 +161,12 @@ impl xwt_core::stream::WriteChunk<xwt_core::stream::chunk::U8> for SendStream {
     }
 }
 
+impl xwt_core::session::datagram::MaxDatagramSize for Connection {
+    fn max_datagram_size(&self) -> Option<usize> {
+        self.0.max_datagram_size()
+    }
+}
+
 impl xwt_core::session::datagram::Receive for Connection {
     type Datagram = Datagram;
     type Error = wtransport::error::ConnectionError;

--- a/crates/xwt-wtransport/src/lib.rs
+++ b/crates/xwt-wtransport/src/lib.rs
@@ -161,7 +161,7 @@ impl xwt_core::stream::WriteChunk<xwt_core::stream::chunk::U8> for SendStream {
     }
 }
 
-impl xwt_core::session::datagram::MaxDatagramSize for Connection {
+impl xwt_core::session::datagram::MaxSize for Connection {
     fn max_datagram_size(&self) -> Option<usize> {
         self.0.max_datagram_size()
     }


### PR DESCRIPTION
Addresses one of the concerns of https://github.com/MOZGIII/xwt/issues/157.

The unit test here is very simple and just checks that the max datagram size is at least `1024`, since that's what's written in the spec. But it doesn't check if you can actually write that many bytes successfully.