### PR TITLE
Implement tokio::io::AsyncRead/AsyncWrite for xwt_wtransport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,6 +890,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2191,7 +2211,7 @@ version = "0.13.2"
 dependencies = [
  "anyhow",
  "color-eyre",
- "pin-project-lite",
+ "pin-project",
  "static_assertions",
  "thiserror",
  "tokio",

--- a/crates/xwt-wtransport/Cargo.toml
+++ b/crates/xwt-wtransport/Cargo.toml
@@ -10,11 +10,11 @@ An implementation of the xwt that runs natively via wtransport crate.
 repository = "https://github.com/MOZGIII/xwt"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-pin-project-lite = "0.2"
-tokio = { version = "1", default-features = false }
 xwt-core = { version = "0.6", path = "../xwt-core", default-features = false, features = ["std"] }
 
+pin-project = "1"
 thiserror = "2"
+tokio = { version = "1", default-features = false }
 wtransport = { version = "0.6", default-features = false, features = ["self-signed", "quinn", "ring"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]

--- a/crates/xwt-wtransport/src/lib.rs
+++ b/crates/xwt-wtransport/src/lib.rs
@@ -82,21 +82,21 @@ impl tokio::io::AsyncWrite for SendStream {
         cx: &mut std::task::Context<'_>,
         buf: &[u8],
     ) -> std::task::Poll<Result<usize, std::io::Error>> {
-        self.project().inner.poll_write(cx, buf)
+        self.project().0.poll_write(cx, buf)
     }
 
     fn poll_flush(
         self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), std::io::Error>> {
-        self.project().inner.poll_flush(cx)
+        self.project().0.poll_flush(cx)
     }
 
     fn poll_shutdown(
         self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), std::io::Error>> {
-        self.project().inner.poll_shutdown(cx)
+        self.project().0.poll_shutdown(cx)
     }
 }
 
@@ -106,7 +106,7 @@ impl tokio::io::AsyncRead for RecvStream {
         cx: &mut std::task::Context<'_>,
         buf: &mut tokio::io::ReadBuf<'_>,
     ) -> std::task::Poll<std::io::Result<()>> {
-        self.project().inner.poll_read(cx, buf)
+        self.project().0.poll_read(cx, buf)
     }
 }
 
@@ -115,7 +115,7 @@ fn map_streams(
     streams: (wtransport::SendStream, wtransport::RecvStream),
 ) -> (SendStream, RecvStream) {
     let (send, recv) = streams;
-    (SendStream { inner: send }, RecvStream { inner: recv })
+    (SendStream(send), RecvStream(recv))
 }
 
 impl xwt_core::session::stream::OpeningBi for OpeningBiStream {
@@ -154,7 +154,7 @@ impl xwt_core::session::stream::OpeningUni for OpeningUniStream {
         self,
     ) -> Result<<Self::Streams as xwt_core::session::stream::SendSpec>::SendStream, Self::Error>
     {
-        self.0.await.map(|i| SendStream { inner: i })
+        self.0.await.map(SendStream)
     }
 }
 
@@ -171,7 +171,7 @@ impl xwt_core::session::stream::AcceptUni for Connection {
     type Error = wtransport::error::ConnectionError;
 
     async fn accept_uni(&self) -> Result<Self::RecvStream, Self::Error> {
-        self.0.accept_uni().await.map(|i| RecvStream { inner: i })
+        self.0.accept_uni().await.map(RecvStream)
     }
 }
 
@@ -180,7 +180,7 @@ impl xwt_core::stream::Read for RecvStream {
     type Error = StreamReadError;
 
     async fn read(&mut self, buf: &mut [u8]) -> Result<NonZeroUsize, Self::Error> {
-        match self.inner.read(buf).await {
+        match self.0.read(buf).await {
             Ok(None) => Err(StreamReadError::Closed),
             Ok(Some(val)) => match NonZeroUsize::new(val) {
                 None => unreachable!(
@@ -199,7 +199,7 @@ impl xwt_core::stream::ReadAbort for RecvStream {
 
     async fn abort(self, error_code: Self::ErrorCode) -> Result<(), Self::Error> {
         let code = error_codes::to_http(error_code.0).try_into().unwrap();
-        self.inner.stop(code);
+        self.0.stop(code);
         Ok(())
     }
 }
@@ -213,11 +213,7 @@ impl xwt_core::stream::Write for SendStream {
             return Err(StreamWriteError::ZeroSizeWriteBuffer);
         }
 
-        let len = self
-            .inner
-            .write(buf)
-            .await
-            .map_err(StreamWriteError::Write)?;
+        let len = self.0.write(buf).await.map_err(StreamWriteError::Write)?;
 
         let Some(len) = NonZeroUsize::new(len) else {
             unreachable!("writing zero bytes into a stream should've lead to a closed error");
@@ -231,7 +227,7 @@ impl xwt_core::stream::WriteChunk<xwt_core::stream::chunk::U8> for SendStream {
     type Error = wtransport::error::StreamWriteError;
 
     async fn write_chunk<'a>(&'a mut self, buf: &'a [u8]) -> Result<(), Self::Error> {
-        self.inner.write_all(buf).await
+        self.0.write_all(buf).await
     }
 }
 
@@ -247,7 +243,7 @@ impl xwt_core::stream::WriteAbort for SendStream {
 
     async fn abort(mut self, error_code: Self::ErrorCode) -> Result<(), Self::Error> {
         let code = error_codes::to_http(error_code.0).try_into().unwrap();
-        self.inner.reset(code)?;
+        self.0.reset(code)?;
         Ok(())
     }
 }
@@ -268,7 +264,7 @@ impl xwt_core::stream::WriteAborted for SendStream {
     type Error = WriteAbortedError;
 
     async fn aborted(mut self) -> Result<Self::ErrorCode, Self::Error> {
-        match self.inner.quic_stream_mut().stopped().await {
+        match self.0.quic_stream_mut().stopped().await {
             Ok(Some(error_code)) => {
                 let code = error_codes::from_http(error_code.into_inner())
                     .map_err(WriteAbortedError::ErrorCodeConversion)?;
@@ -289,7 +285,7 @@ impl xwt_core::stream::Finish for SendStream {
     type Error = wtransport::error::StreamWriteError;
 
     async fn finish(mut self) -> Result<(), Self::Error> {
-        self.inner.finish().await
+        self.0.finish().await
     }
 }
 

--- a/crates/xwt-wtransport/src/types.rs
+++ b/crates/xwt-wtransport/src/types.rs
@@ -63,16 +63,13 @@ macro_rules! newtype {
 }
 
 /// Create a newtype wrapper with pin projection for a given type.
+
+/// Create a newtype wrapper for a given type.
 macro_rules! newtype_pin {
     ($name:ident => $wrapped_type:path) => {
-        pin_project_lite::pin_project! {
-            #[doc = concat!("The [`", stringify!($wrapped_type), "`] newtype with pin projection.")]
-            #[allow(missing_docs)]
-            pub struct $name {
-                #[pin]
-                pub inner: $wrapped_type,
-            }
-        }
+        #[pin_project::pin_project]
+        #[doc = concat!("The [`", stringify!($wrapped_type), "`] newtype.")]
+        pub struct $name(#[pin] pub $wrapped_type);
 
         impl std::fmt::Debug for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -82,13 +79,49 @@ macro_rules! newtype_pin {
 
         impl From<$wrapped_type> for $name {
             fn from(value: $wrapped_type) -> Self {
-                Self { inner: value }
+                Self(value)
             }
         }
 
         impl From<$name> for $wrapped_type {
             fn from(value: $name) -> Self {
-                value.inner
+                value.0
+            }
+        }
+    };
+    ($name:ident < $($generics:tt),* > => $wrapped_type:path) => {
+        #[doc = concat!("The [`", stringify!($wrapped_type), "`] newtype.")]
+        pub struct $name<$($generics)*>(pub $wrapped_type);
+
+        impl<$($generics)*> std::fmt::Debug for $name<$($generics)*> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_tuple(stringify!($name)).finish()
+            }
+        }
+
+        impl<$($generics)*> From<$wrapped_type> for $name<$($generics)*> {
+            fn from(value: $wrapped_type) -> Self {
+                Self(value)
+            }
+        }
+
+        impl<$($generics)*> From<$name<$($generics)*>> for $wrapped_type {
+            fn from(value: $name<$($generics)*>) -> Self {
+                value.0
+            }
+        }
+
+        impl<$($generics)*> std::ops::Deref for $name<$($generics)*> {
+            type Target = $wrapped_type;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl<$($generics)*> std::ops::DerefMut for $name<$($generics)*> {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.0
             }
         }
     };


### PR DESCRIPTION
Closes https://github.com/MOZGIII/xwt/issues/179

Unfortunately `pin-project-lite` (unlike `pin-project`) does not support:
- Tuple fields, they must be named instead
- Field comments

(See https://github.com/taiki-e/pin-project-lite/issues/50)

So the inner .0 was renamed to inner, and the warning was disabled for missing doc comment.

Let me know if you'd like a different approach!