### PR TITLE
Refactor generic Pending with operation-specific enum variants

### DIFF
--- a/crates/web-sys-async-io/src/lib.rs
+++ b/crates/web-sys-async-io/src/lib.rs
@@ -24,5 +24,8 @@ fn js_value_to_io_error(error: wasm_bindgen::JsValue) -> std::io::Error {
 pub enum Op {
     #[default]
     Idle,
-    Pending(JsFuture),
+    Write(JsFuture, usize),
+    Read(JsFuture),
+    Flush(JsFuture),
+    Shutdown(JsFuture),
 }

--- a/crates/web-sys-async-io/src/lib.rs
+++ b/crates/web-sys-async-io/src/lib.rs
@@ -21,11 +21,10 @@ fn js_value_to_io_error(error: wasm_bindgen::JsValue) -> std::io::Error {
 }
 
 #[derive(Debug, Default)]
-pub enum Op {
+pub enum WriterOp {
     #[default]
     Idle,
     Write(JsFuture, usize),
-    Read(JsFuture),
     Flush(JsFuture),
     Shutdown(JsFuture),
 }

--- a/crates/web-sys-async-io/src/lib.rs
+++ b/crates/web-sys-async-io/src/lib.rs
@@ -28,3 +28,11 @@ pub enum WriterOp {
     Flush(JsFuture),
     Shutdown(JsFuture),
 }
+
+#[derive(Debug, Default)]
+pub enum ReaderOp {
+    #[default]
+    Idle,
+    Read(JsFuture),
+    ReadRemaining(js_sys::Uint8Array, usize),
+}


### PR DESCRIPTION
Replaces the generic `Pending(JsFuture)` enum variant with specific operation types: `Write(JsFuture, usize)`, `Read(JsFuture)`, `Flush(JsFuture)`, and `Shutdown(JsFuture)`,

which pr fixes:

1. Incorrect byte size returning: `poll_write` was returning the size of the current buffer instead of the size of the buffer that was actually written in the previous operation.

2. Operation state confusion: All operations (write, flush, shutdown) shared a single `Pending` state, causing incorrect behavior when operations were interleaved.
