### PR TITLE
Drop the self-signed feature from wtransport and make it's ring dep optional

### DIFF
--- a/crates/xwt-wtransport/Cargo.toml
+++ b/crates/xwt-wtransport/Cargo.toml
@@ -14,7 +14,7 @@ xwt-core = { version = "0.9", path = "../xwt-core", default-features = false, fe
 
 thiserror = "2"
 tokio = { version = "1", default-features = false, optional = true }
-wtransport = { version = "0.7", default-features = false, features = ["self-signed", "quinn", "ring"] }
+wtransport = { version = "0.7", default-features = false, features = ["quinn"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 xwt-cert-fingerprint = { version = "0.1", path = "../xwt-cert-fingerprint" }
@@ -28,4 +28,4 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 
 [features]
-default = ["tokio"]
+default = ["tokio", "wtransport/ring"]


### PR DESCRIPTION
Supersedes https://github.com/MOZGIII/xwt/pull/223

Closes #177

@xangelix you can try it yourself: `cargo clippy -p xwt-wtransport --no-default-features --features "wtransport/aws-lc-rs"`