### PR TITLE
move every dependency to workspace root for easier management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +151,12 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -679,10 +696,12 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -698,6 +717,12 @@ name = "libc"
 version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "litemap"
@@ -719,9 +744,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "minicov"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
 dependencies = [
  "cc",
  "walkdir",
@@ -804,6 +829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -835,6 +861,12 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
@@ -995,7 +1027,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1210,6 +1242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1230,6 +1263,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1569,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "typle"
@@ -1650,48 +1696,32 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1699,44 +1729,53 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.50"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c8d5e33ca3b6d9fa3b4676d774c5778031d27a578c2b007f905acf816152c3"
+checksum = "af5ec93229ad9ccd0a545a516dec76dc276613f278f6a91aa6b463d5b33d42d0"
 dependencies = [
+ "async-trait",
+ "cast",
  "js-sys",
+ "libm",
  "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.50"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
+checksum = "3c81b9fef827e575e0e54431736d1baa0d700315d8c62cfef1f61fa3aad0cbeb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1744,10 +1783,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.77"
+name = "wasm-bindgen-test-shared"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "4f4d8ae7ad5440360e9799dfd42857d126454a88441ddf72d288ef83fa47f527"
+
+[[package]]
+name = "web-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1803,7 +1848,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2429,3 +2474,9 @@ name = "zip_clone"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "605a55f6dd6f8ef8fe0c08a6a08d87282b4d23800a1cde76941f495a4c00d1d4"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,58 @@
 [workspace]
 members = ["crates/*", "examples/*/*"]
 resolver = "2"
+
+[workspace.dependencies]
+# External dependencies
+async-timer = { version = "1.0.0-beta.13", features = ["tokio1"] }
+base64 = { version = "0.22", default-features = false, features = ["alloc"] }
+cfg-if = "1"
+color-eyre = { version = "0.6" }
+console_error_panic_hook = "0.1"
+constcat = "0.5.0"
+der = { version = "0.7", default-features = false, features = ["alloc"] }
+dyn_safe = "0.1"
+envfury = { version = "0.2" }
+futures-util = "0.3"
+getrandom = { version = "0.2", features = ["js"] }
+js-sys = { version = "0.3" }
+p256 = { version = "0.13", features = ["ecdsa", "pkcs8"] }
+pastey = "0.1"
+rand = { version = "0.8" }
+rustls-pki-types = { version = "1", default-features = false }
+sha2 = { version = "0.10", default-features = false }
+signature = { version = "2.2", default-features = false, features = ["alloc"] }
+spki = { version = "0.7", default-features = false, features = ["alloc", "fingerprint"] }
+static_assertions = "1"
+thiserror = "2"
+time = { version = "0.3.38", default-features = false, features = ["std", "formatting", "parsing"] }
+tokio = { version = "1", default-features = false }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3" }
+tracing-wasm = "0.2"
+typle = "0.10"
+wasm-bindgen = { version = "0.2" }
+wasm-bindgen-futures = { version = "0.4" }
+wasm-bindgen-test = "0.3"
+web-sys = { version = "0.3" }
+wtransport = { version = "0.7", default-features = false, features = ["quinn"] }
+x509-cert = { version = "0.2", default-features = false, features = ["pem", "builder"] }
+
+# Internal workspace crates
+web-sys-async-io = { version = "0.5", path = "crates/web-sys-async-io" }
+web-sys-stream-utils = { version = "0.2", path = "crates/web-sys-stream-utils" }
+web-wt-sys = { version = "0.2", path = "crates/web-wt-sys", default-features = false }
+xwt = { version = "0.18", path = "crates/xwt" }
+xwt-anchor = { version = "0.8", path = "crates/xwt-anchor", default-features = false }
+xwt-cert-fingerprint = { version = "0.1", path = "crates/xwt-cert-fingerprint", default-features = false }
+xwt-cert-gen = { version = "0.2", path = "crates/xwt-cert-gen" }
+xwt-core = { version = "0.9", path = "crates/xwt-core", default-features = false }
+xwt-dyn = { version = "0.3", path = "crates/xwt-dyn", default-features = false }
+xwt-erased = { version = "0.6", path = "crates/xwt-erased", default-features = false }
+xwt-erased-error = { version = "0.6", path = "crates/xwt-erased-error", default-features = false }
+xwt-error = { version = "0.9", path = "crates/xwt-error", default-features = false }
+xwt-test-assets = { version = "0.2", path = "crates/xwt-test-assets" }
+xwt-test-assets-build = { version = "0.4", path = "crates/xwt-test-assets-build", default-features = false }
+xwt-tests = { version = "0.12", path = "crates/xwt-tests" }
+xwt-web = { version = "0.20", path = "crates/xwt-web", default-features = false }
+xwt-wtransport = { version = "0.19", path = "crates/xwt-wtransport", default-features = false }

--- a/crates/web-sys-async-io/Cargo.toml
+++ b/crates/web-sys-async-io/Cargo.toml
@@ -14,8 +14,8 @@ repository = "https://github.com/MOZGIII/xwt"
 default-target = "wasm32-unknown-unknown"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-js-sys = "0.3"
-tokio = { version = "1", default-features = false, features = [] }
-wasm-bindgen = { version = "0.2" }
-wasm-bindgen-futures = { version = "0.4" }
-web-sys = { version = "0.3", features = ["ReadableStreamDefaultReader", "WritableStreamDefaultWriter"] }
+js-sys = { workspace = true }
+tokio = { workspace = true, default-features = false, features = [] }
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+web-sys = { workspace = true, features = ["ReadableStreamDefaultReader", "WritableStreamDefaultWriter"] }

--- a/crates/web-sys-stream-utils/Cargo.toml
+++ b/crates/web-sys-stream-utils/Cargo.toml
@@ -13,10 +13,10 @@ repository = "https://github.com/MOZGIII/xwt"
 default-target = "wasm32-unknown-unknown"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-js-sys = "0.3"
-wasm-bindgen = { version = "0.2" }
-wasm-bindgen-futures = { version = "0.4" }
-web-sys = { version = "0.3", features = [
+js-sys = { workspace = true }
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+web-sys = { workspace = true, features = [
   "ReadableStreamDefaultReader",
   "ReadableStreamGetReaderOptions",
   "ReadableStreamReaderMode",

--- a/crates/web-wt-sys/Cargo.toml
+++ b/crates/web-wt-sys/Cargo.toml
@@ -16,8 +16,8 @@ default-target = "wasm32-unknown-unknown"
 ignored = ["wasm-bindgen-futures"]
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-js-sys = "0.3.69"
-pastey = "0.1"
+js-sys = { version = "0.3.69" }
+pastey = { workspace = true }
 wasm-bindgen = { version = "0.2.93" }
 wasm-bindgen-futures = { version = "0.4.43" }
 web-sys = { version = "0.3.70", features = [
@@ -29,6 +29,6 @@ web-sys = { version = "0.3.70", features = [
 ] }
 
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
-tracing-wasm = "0.2"
+tracing-wasm = { workspace = true }
 wasm-bindgen-test = "0.3.43"
 web-sys = { version = "0.3.70", features = ["console"] }

--- a/crates/xwt-anchor/Cargo.toml
+++ b/crates/xwt-anchor/Cargo.toml
@@ -11,4 +11,4 @@ Useful to overcome foreign type implementation limitations.
 repository = "https://github.com/MOZGIII/xwt"
 
 [dependencies]
-xwt-core = { version = "0.9", path = "../xwt-core", default-features = false }
+xwt-core = { workspace = true }

--- a/crates/xwt-cert-fingerprint/Cargo.toml
+++ b/crates/xwt-cert-fingerprint/Cargo.toml
@@ -12,10 +12,10 @@ Intended to work with both wasm and native.
 repository = "https://github.com/MOZGIII/xwt"
 
 [dependencies]
-base64 = { version = "0.22", optional = true, default-features = false, features = ["alloc"] }
-rustls-pki-types = { version = "1", optional = true, default-features = false }
+base64 = { workspace = true, optional = true }
+rustls-pki-types = { workspace = true, optional = true }
 sha2 = { version = "0.10", default-features = false }
-x509-cert = { version = "0.2", optional = true, default-features = false }
+x509-cert = { workspace = true, optional = true }
 
 [features]
 default = ["alloc"]

--- a/crates/xwt-cert-gen/Cargo.toml
+++ b/crates/xwt-cert-gen/Cargo.toml
@@ -14,14 +14,14 @@ repository = "https://github.com/MOZGIII/xwt"
 ignored = ["sha2", "p256", "spki", "rand", "getrandom"]
 
 [dependencies]
-der = { version = "0.7", default-features = false, features = ["alloc"] }
-getrandom = { version = "0.2", features = ["js"] }
-sha2 = { version = "0.10", default-features = false, features = ["oid"] }
-signature = { version = "2.2", default-features = false, features = ["alloc"] }
-spki = { version = "0.7", default-features = false, features = ["alloc", "fingerprint"] }
-thiserror = "2"
-x509-cert = { version = "0.2", default-features = false, features = ["pem", "builder"] }
+der = { workspace = true }
+getrandom = { workspace = true }
+sha2 = { workspace = true, features = ["oid"] }
+signature = { workspace = true }
+spki = { workspace = true }
+thiserror = { workspace = true }
+x509-cert = { workspace = true }
 
 [dev-dependencies]
 p256 = { version = "0.13", features = ["ecdsa"] }
-rand = { version = "0.8" }
+rand = { workspace = true }

--- a/crates/xwt-dyn/Cargo.toml
+++ b/crates/xwt-dyn/Cargo.toml
@@ -11,9 +11,9 @@ A suite of dyn-safe companion traits for xwt-core.
 repository = "https://github.com/MOZGIII/xwt"
 
 [dependencies]
-xwt-core = { version = "0.9", path = "../xwt-core", default-features = false }
+xwt-core = { workspace = true }
 
-dyn_safe = "0.1"
+dyn_safe = { workspace = true }
 
 [features]
 default = ["std"]

--- a/crates/xwt-erased-error/Cargo.toml
+++ b/crates/xwt-erased-error/Cargo.toml
@@ -11,4 +11,4 @@ Use when you don't want/need your own more precise types.
 repository = "https://github.com/MOZGIII/xwt"
 
 [dependencies]
-xwt-erased = { version = "0.6", path = "../xwt-erased", default-features = false }
+xwt-erased = { workspace = true }

--- a/crates/xwt-erased/Cargo.toml
+++ b/crates/xwt-erased/Cargo.toml
@@ -11,22 +11,22 @@ Type-erased wrappers for the `xwt-dyn` traits.
 repository = "https://github.com/MOZGIII/xwt"
 
 [dependencies]
-xwt-core = { version = "0.9", path = "../xwt-core", default-features = false, optional = true }
-xwt-dyn = { version = "0.3", path = "../xwt-dyn", default-features = false }
+xwt-core = { workspace = true, optional = true }
+xwt-dyn = { workspace = true }
 
-static_assertions = { version = "1", optional = true }
-tracing = { version = "0.1", default-features = false, optional = true }
+static_assertions = { workspace = true, optional = true }
+tracing = { workspace = true, default-features = false, optional = true }
 
 [dev-dependencies]
-tracing = "0.1"
+tracing = { workspace = true }
 
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
-xwt-web = { version = "0.20", path = "../xwt-web", default-features = false }
+xwt-web = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
-xwt-wtransport = { version = "0.19", path = "../xwt-wtransport", default-features = false }
+xwt-wtransport = { workspace = true }
 
-wtransport = { version = "0.7", default-features = false }
+wtransport = { workspace = true }
 
 [features]
 default = ["core-compat"]

--- a/crates/xwt-error/Cargo.toml
+++ b/crates/xwt-error/Cargo.toml
@@ -12,4 +12,4 @@ Use when you don't want/need your own more precise types.
 repository = "https://github.com/MOZGIII/xwt"
 
 [dependencies]
-xwt-core = { version = "0.9", path = "../xwt-core", default-features = false }
+xwt-core = { workspace = true }

--- a/crates/xwt-test-assets-build/Cargo.toml
+++ b/crates/xwt-test-assets-build/Cargo.toml
@@ -10,8 +10,8 @@ A static assets generation utility.
 repository = "https://github.com/MOZGIII/xwt"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-xwt-cert-gen = { version = "0.2", path = "../xwt-cert-gen" }
+xwt-cert-gen = { workspace = true }
 
-p256 = { version = "0.13", features = ["ecdsa", "pkcs8"] }
-rand = "0.8"
-time = { version = "0.3.38", default-features = false, features = ["std", "formatting", "parsing"] }
+p256 = { workspace = true }
+rand = { workspace = true }
+time = { workspace = true }

--- a/crates/xwt-test-assets/Cargo.toml
+++ b/crates/xwt-test-assets/Cargo.toml
@@ -12,4 +12,4 @@ repository = "https://github.com/MOZGIII/xwt"
 [dependencies]
 
 [build-dependencies]
-xwt-test-assets-build = { version = "0.4", path = "../xwt-test-assets-build", default-features = false }
+xwt-test-assets-build = { workspace = true }

--- a/crates/xwt-test-server/Cargo.toml
+++ b/crates/xwt-test-server/Cargo.toml
@@ -17,17 +17,17 @@ path = "src/main.rs"
 required-features = ["bin"]
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-xwt-cert-fingerprint = { version = "0.1", path = "../xwt-cert-fingerprint" }
-xwt-test-assets = { version = "0.2", path = "../xwt-test-assets" }
+xwt-cert-fingerprint = { workspace = true }
+xwt-test-assets = { workspace = true }
 
-color-eyre = { version = "0.6", optional = true }
-envfury = { version = "0.2", optional = true }
-thiserror = "2"
-tokio = { version = "1", default-features = false, features = ["rt-multi-thread"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", optional = true }
-typle = "0.10"
-wtransport = { version = "0.7", default-features = false, features = ["quinn"] }
+color-eyre = { workspace = true, optional = true }
+envfury = { workspace = true, optional = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, optional = true }
+typle = { workspace = true }
+wtransport = { workspace = true }
 
 [features]
 bin = ["dep:color-eyre", "dep:envfury", "dep:tracing-subscriber", "tokio/macros", "wtransport/ring"]

--- a/crates/xwt-tests/Cargo.toml
+++ b/crates/xwt-tests/Cargo.toml
@@ -12,10 +12,10 @@ environments.
 repository = "https://github.com/MOZGIII/xwt"
 
 [dependencies]
-xwt-core = { version = "0.9", path = "../xwt-core", default-features = false }
-xwt-error = { version = "0.9", path = "../xwt-error", default-features = false }
+xwt-core = { workspace = true }
+xwt-error = { workspace = true }
 
-constcat = "0.5.0"
-thiserror = "2"
-tokio = { version = "1", default-features = false, features = ["io-util"] }
-tracing = "0.1"
+constcat = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["io-util"] }
+tracing = { workspace = true }

--- a/crates/xwt-web/Cargo.toml
+++ b/crates/xwt-web/Cargo.toml
@@ -14,24 +14,24 @@ repository = "https://github.com/MOZGIII/xwt"
 default-target = "wasm32-unknown-unknown"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-web-sys-async-io = { version = "0.5", path = "../web-sys-async-io" }
-web-sys-stream-utils = { version = "0.2", path = "../web-sys-stream-utils" }
-web-wt-sys = { version = "0.2", path = "../web-wt-sys", default-features = false }
-xwt-core = { version = "0.9", path = "../xwt-core", default-features = false }
+web-sys-async-io = { workspace = true }
+web-sys-stream-utils = { workspace = true }
+web-wt-sys = { workspace = true }
+xwt-core = { workspace = true }
 
-js-sys = "0.3"
-thiserror = "2"
-tokio = { version = "1", default-features = false, features = ["sync"] }
-wasm-bindgen = { version = "0.2" }
-wasm-bindgen-futures = { version = "0.4" }
-web-sys = { version = "0.3", features = ["ReadableStream", "WritableStream", "DomException"] }
+js-sys = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+web-sys = { workspace = true, features = ["ReadableStream", "WritableStream", "DomException"] }
 
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
-xwt-cert-fingerprint = { version = "0.1", path = "../xwt-cert-fingerprint", default-features = false }
-xwt-test-assets = { version = "0.2", path = "../xwt-test-assets" }
-xwt-tests = { version = "0.12", path = "../xwt-tests" }
+xwt-cert-fingerprint = { workspace = true }
+xwt-test-assets = { workspace = true }
+xwt-tests = { workspace = true }
 
-static_assertions = "1"
-tracing-wasm = "0.2"
-wasm-bindgen-test = "0.3"
-web-sys = { version = "0.3", features = ["console"] }
+static_assertions = { workspace = true }
+tracing-wasm = { workspace = true }
+wasm-bindgen-test = { workspace = true }
+web-sys = { workspace = true, features = ["console"] }

--- a/crates/xwt-wtransport/Cargo.toml
+++ b/crates/xwt-wtransport/Cargo.toml
@@ -10,22 +10,22 @@ An implementation of the xwt that runs natively via wtransport crate.
 repository = "https://github.com/MOZGIII/xwt"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-xwt-core = { version = "0.9", path = "../xwt-core", default-features = false, features = ["std"] }
+xwt-core = { workspace = true, features = ["std"] }
 
-thiserror = "2"
-tokio = { version = "1", default-features = false, optional = true }
-wtransport = { version = "0.7", default-features = false, features = ["quinn"] }
+thiserror = { workspace = true }
+tokio = { workspace = true, default-features = false, optional = true }
+wtransport = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
-xwt-cert-fingerprint = { version = "0.1", path = "../xwt-cert-fingerprint" }
-xwt-test-assets = { version = "0.2", path = "../xwt-test-assets" }
-xwt-tests = { version = "0.12", path = "../xwt-tests" }
+xwt-cert-fingerprint = { workspace = true }
+xwt-test-assets = { workspace = true }
+xwt-tests = { workspace = true }
 
-color-eyre = "0.6"
-static_assertions = "1"
-tokio = { version = "1", features = ["macros"] }
-tracing = "0.1"
-tracing-subscriber = "0.3"
+color-eyre = { workspace = true }
+static_assertions = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [features]
 default = ["tokio", "wtransport/ring"]

--- a/examples/microapp-erased/client-native/Cargo.toml
+++ b/examples/microapp-erased/client-native/Cargo.toml
@@ -9,14 +9,14 @@ publish = false
 xwt-erased-example-client-shared = { path = "../client-shared", default-features = false }
 
 # Core xwt primitives and driver.
-xwt-cert-fingerprint = { path = "../../../crates/xwt-cert-fingerprint", default-features = false }
-xwt-erased = { path = "../../../crates/xwt-erased", default-features = false }
-xwt-wtransport = { path = "../../../crates/xwt-wtransport", default-features = false }
+xwt-cert-fingerprint = { workspace = true }
+xwt-erased = { workspace = true }
+xwt-wtransport = { workspace = true }
 
 # The dependency specific to this being an xwt example that is designed to
 # work with an xwt test server.
-xwt-test-assets = { path = "../../../crates/xwt-test-assets", default-features = false }
+xwt-test-assets = { workspace = true }
 
 # The rest of the dependencies.
-rand = "0.8"
-wtransport = { version = "0.7", default-features = false, features = ["ring"] }
+rand = { workspace = true }
+wtransport = { workspace = true, features = ["ring"] }

--- a/examples/microapp-erased/client-shared/Cargo.toml
+++ b/examples/microapp-erased/client-shared/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-xwt-erased = { path = "../../../crates/xwt-erased" }
+xwt-erased = { workspace = true }
 
-async-timer = { version = "1.0.0-beta.13", features = ["tokio1"] }
-futures-util = "0.3"
-rand = "0.8"
+async-timer = { workspace = true }
+futures-util = { workspace = true }
+rand = { workspace = true }

--- a/examples/microapp-erased/client-web/Cargo.toml
+++ b/examples/microapp-erased/client-web/Cargo.toml
@@ -12,17 +12,17 @@ ignored = ["getrandom"]
 xwt-erased-example-client-shared = { path = "../client-shared", default-features = false }
 
 # Core xwt primitives and driver.
-xwt-cert-fingerprint = { path = "../../../crates/xwt-cert-fingerprint", default-features = false }
-xwt-core = { path = "../../../crates/xwt-core", default-features = false }
-xwt-erased = { path = "../../../crates/xwt-erased", default-features = false }
-xwt-web = { path = "../../../crates/xwt-web", default-features = false }
+xwt-cert-fingerprint = { workspace = true }
+xwt-core = { workspace = true }
+xwt-erased = { workspace = true }
+xwt-web = { workspace = true }
 
 # The dependency specific to this being an xwt example that is designed to
 # work with an xwt test server.
-xwt-test-assets = { path = "../../../crates/xwt-test-assets", default-features = false }
+xwt-test-assets = { workspace = true }
 
 # The rest of the dependencies.
-getrandom = { version = "0.2", features = ["js"] }
-rand = "0.8"
-wasm-bindgen = "0.2"
-web-sys = { version = "0.3", features = ["Window", "Document", "HtmlElement"] }
+getrandom = { workspace = true }
+rand = { workspace = true }
+wasm-bindgen = { workspace = true }
+web-sys = { workspace = true, features = ["Window", "Document", "HtmlElement"] }

--- a/examples/microapp-erased/client/Cargo.toml
+++ b/examples/microapp-erased/client/Cargo.toml
@@ -5,15 +5,15 @@ edition = "2021"
 publish = false
 
 [dependencies]
-cfg-if = "1"
+cfg-if = { workspace = true }
 
 xwt-erased-example-client-shared = { version = "0.1", path = "../client-shared", default-features = false }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-console_error_panic_hook = "0.1"
-wasm-bindgen-futures = "0.4"
+console_error_panic_hook = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
 xwt-erased-example-client-web = { version = "0.1", path = "../client-web", default-features = false }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 xwt-erased-example-client-native = { version = "0.1", path = "../client-native", default-features = false }

--- a/examples/microapp-erased/server-native/Cargo.toml
+++ b/examples/microapp-erased/server-native/Cargo.toml
@@ -9,13 +9,13 @@ publish = false
 xwt-erased-example-server-shared = { path = "../server-shared", default-features = false }
 
 # Core xwt primitives and driver.
-xwt-erased = { path = "../../../crates/xwt-erased", default-features = false }
-xwt-wtransport = { path = "../../../crates/xwt-wtransport", default-features = false }
+xwt-erased = { workspace = true }
+xwt-wtransport = { workspace = true }
 
 # The dependency specific to this being an xwt example that is designed to
 # work with an xwt test server.
-xwt-test-assets = { path = "../../../crates/xwt-test-assets", default-features = false }
+xwt-test-assets = { workspace = true }
 
 # The rest of the dependencies.
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-wtransport = { version = "0.7", default-features = false, features = ["ring"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+wtransport = { workspace = true, features = ["ring"] }

--- a/examples/microapp-erased/server-shared/Cargo.toml
+++ b/examples/microapp-erased/server-shared/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-xwt-erased = { path = "../../../crates/xwt-erased" }
+xwt-erased = { workspace = true }
 
-futures-util = "0.3"
-tokio = { version = "1", default-features = false, features = ["time"] }
+futures-util = { workspace = true }
+tokio = { workspace = true, default-features = false, features = ["time"] }

--- a/examples/microapp-erased/server/Cargo.toml
+++ b/examples/microapp-erased/server/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 publish = false
 
 [dependencies]
-cfg-if = "1"
+cfg-if = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 xwt-erased-example-server-native = { path = "../server-native", default-features = false }
 
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/examples/microapp/client-native/Cargo.toml
+++ b/examples/microapp/client-native/Cargo.toml
@@ -12,15 +12,15 @@ ignored = ["tokio"]
 xwt-example-client-shared = { path = "../client-shared", default-features = false }
 
 # Core xwt primitives and driver.
-xwt-cert-fingerprint = { path = "../../../crates/xwt-cert-fingerprint", default-features = false }
-xwt-core = { path = "../../../crates/xwt-core", default-features = false }
-xwt-wtransport = { path = "../../../crates/xwt-wtransport", default-features = false }
+xwt-cert-fingerprint = { workspace = true }
+xwt-core = { workspace = true }
+xwt-wtransport = { workspace = true }
 
 # The dependency specific to this being an xwt example that is designed to
 # work with an xwt test server.
-xwt-test-assets = { path = "../../../crates/xwt-test-assets", default-features = false }
+xwt-test-assets = { workspace = true }
 
 # The rest of the dependencies.
-rand = "0.8"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-wtransport = { version = "0.7", default-features = false, features = ["ring"] }
+rand = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+wtransport = { workspace = true, features = ["ring"] }

--- a/examples/microapp/client-shared/Cargo.toml
+++ b/examples/microapp/client-shared/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-xwt-core = { path = "../../../crates/xwt-core" }
+xwt-core = { workspace = true }
 
-async-timer = { version = "1.0.0-beta.13", features = ["tokio1"] }
-futures-util = "0.3"
-rand = "0.8"
+async-timer = { workspace = true }
+futures-util = { workspace = true }
+rand = { workspace = true }

--- a/examples/microapp/client-web/Cargo.toml
+++ b/examples/microapp/client-web/Cargo.toml
@@ -12,16 +12,16 @@ ignored = ["getrandom"]
 xwt-example-client-shared = { path = "../client-shared", default-features = false }
 
 # Core xwt primitives and driver.
-xwt-cert-fingerprint = { path = "../../../crates/xwt-cert-fingerprint", default-features = false }
-xwt-core = { path = "../../../crates/xwt-core", default-features = false }
-xwt-web = { path = "../../../crates/xwt-web", default-features = false }
+xwt-cert-fingerprint = { workspace = true }
+xwt-core = { workspace = true }
+xwt-web = { workspace = true }
 
 # The dependency specific to this being an xwt example that is designed to
 # work with an xwt test server.
-xwt-test-assets = { path = "../../../crates/xwt-test-assets", default-features = false }
+xwt-test-assets = { workspace = true }
 
 # The rest of the dependencies.
-getrandom = { version = "0.2", features = ["js"] }
-rand = "0.8"
-wasm-bindgen = "0.2"
-web-sys = { version = "0.3", features = ["Window", "Document", "HtmlElement"] }
+getrandom = { workspace = true }
+rand = { workspace = true }
+wasm-bindgen = { workspace = true }
+web-sys = { workspace = true, features = ["Window", "Document", "HtmlElement"] }

--- a/examples/microapp/client/Cargo.toml
+++ b/examples/microapp/client/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 publish = false
 
 [dependencies]
-cfg-if = "1"
+cfg-if = { workspace = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-console_error_panic_hook = "0.1"
-wasm-bindgen-futures = "0.4"
+console_error_panic_hook = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
 xwt-example-client-web = { version = "0.1", path = "../client-web", default-features = false }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 xwt-example-client-native = { version = "0.1", path = "../client-native", default-features = false }

--- a/examples/microapp/server-native/Cargo.toml
+++ b/examples/microapp/server-native/Cargo.toml
@@ -9,13 +9,13 @@ publish = false
 xwt-example-server-shared = { path = "../server-shared", default-features = false }
 
 # Core xwt primitives and driver.
-xwt-core = { path = "../../../crates/xwt-core", default-features = false }
-xwt-wtransport = { path = "../../../crates/xwt-wtransport", default-features = false }
+xwt-core = { workspace = true }
+xwt-wtransport = { workspace = true }
 
 # The dependency specific to this being an xwt example that is designed to
 # work with an xwt test server.
-xwt-test-assets = { path = "../../../crates/xwt-test-assets", default-features = false }
+xwt-test-assets = { workspace = true }
 
 # The rest of the dependencies.
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-wtransport = { version = "0.7", default-features = false, features = ["ring"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+wtransport = { workspace = true, features = ["ring"] }

--- a/examples/microapp/server-shared/Cargo.toml
+++ b/examples/microapp/server-shared/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-xwt-core = { path = "../../../crates/xwt-core" }
+xwt-core = { workspace = true }
 
-futures-util = "0.3"
-tokio = { version = "1", default-features = false, features = ["time"] }
+futures-util = { workspace = true }
+tokio = { workspace = true, default-features = false, features = ["time"] }

--- a/examples/microapp/server/Cargo.toml
+++ b/examples/microapp/server/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 publish = false
 
 [dependencies]
-cfg-if = "1"
+cfg-if = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 xwt-example-server-native = { path = "../server-native", default-features = false }
 
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
I checked both the native and wasm tests, and all of them pass.

I did this because otherwise trying to update all of the dependencies was a nightmare