### PR TITLE
`getReader` Byob fallback

### DIFF
--- a/crates/web-sys-async-io/Cargo.toml
+++ b/crates/web-sys-async-io/Cargo.toml
@@ -18,4 +18,4 @@ js-sys = "0.3"
 tokio = { version = "1", default-features = false, features = [] }
 wasm-bindgen = { version = "0.2" }
 wasm-bindgen-futures = { version = "0.4" }
-web-sys = { version = "0.3", features = ["ReadableStreamDefaultReader", "WritableStreamDefaultWriter"] }
+web-sys = { version = "0.3", features = ["ReadableStreamByobReader", "ReadableStreamDefaultReader", "WritableStreamDefaultWriter"] }

--- a/crates/web-sys-async-io/src/lib.rs
+++ b/crates/web-sys-async-io/src/lib.rs
@@ -10,7 +10,7 @@ pub mod reader;
 mod sys;
 pub mod writer;
 
-pub use self::reader::Reader;
+pub use self::reader::{ReadableStreamReader, Reader};
 pub use self::writer::Writer;
 
 fn js_value_to_io_error(error: wasm_bindgen::JsValue) -> std::io::Error {

--- a/crates/web-sys-async-io/src/reader.rs
+++ b/crates/web-sys-async-io/src/reader.rs
@@ -6,6 +6,35 @@ use std::{
 
 use wasm_bindgen_futures::JsFuture;
 
+#[derive(Clone, Debug)]
+pub enum ReadableStreamReader {
+    Byob(web_sys::ReadableStreamByobReader),
+    Default(web_sys::ReadableStreamDefaultReader),
+}
+
+impl ReadableStreamReader {
+    pub fn release_lock(&self) {
+        match self {
+            Self::Byob(reader) => reader.release_lock(),
+            Self::Default(reader) => reader.release_lock(),
+        }
+    }
+
+    pub fn closed(&self) -> js_sys::Promise {
+        match self {
+            Self::Byob(reader) => reader.closed(),
+            Self::Default(reader) => reader.closed(),
+        }
+    }
+
+    pub fn cancel_with_reason(&self, reason: &wasm_bindgen::JsValue) -> js_sys::Promise {
+        match self {
+            Self::Byob(reader) => reader.cancel_with_reason(reason),
+            Self::Default(reader) => reader.cancel_with_reason(reason),
+        }
+    }
+}
+
 #[derive(Debug, Default)]
 pub enum Op {
     #[default]
@@ -19,7 +48,7 @@ pub enum Op {
 
 #[derive(Debug)]
 pub struct Reader {
-    pub inner: web_sys::ReadableStreamByobReader,
+    pub inner: ReadableStreamReader,
     pub op: Op,
     pub internal_buf: Option<js_sys::ArrayBuffer>,
 }
@@ -27,7 +56,15 @@ pub struct Reader {
 impl Reader {
     pub fn new(inner: web_sys::ReadableStreamByobReader) -> Self {
         Self {
-            inner,
+            inner: ReadableStreamReader::Byob(inner),
+            op: Op::default(),
+            internal_buf: None,
+        }
+    }
+
+    pub fn new_default(inner: web_sys::ReadableStreamDefaultReader) -> Self {
+        Self {
+            inner: ReadableStreamReader::Default(inner),
             op: Op::default(),
             internal_buf: None,
         }
@@ -38,26 +75,31 @@ impl Reader {
         internal_buf: js_sys::ArrayBuffer,
     ) -> Self {
         Self {
-            inner,
+            inner: ReadableStreamReader::Byob(inner),
             op: Op::default(),
             internal_buf: Some(internal_buf),
         }
     }
 }
 
-impl tokio::io::AsyncRead for Reader {
-    fn poll_read(
+impl Reader {
+    pub fn poll_read_js(
         mut self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
         buf: &mut tokio::io::ReadBuf<'_>,
-    ) -> Poll<std::io::Result<()>> {
+    ) -> Poll<Result<(), wasm_bindgen::JsValue>> {
+        if buf.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+
+        let is_byob = matches!(self.inner, ReadableStreamReader::Byob(_));
         match self.op {
             Op::ReadPending(ref mut fut) => {
                 let result = ready!(Pin::new(fut).poll(cx));
 
                 let read_result = match result {
                     Ok(val) => val,
-                    Err(err) => return Poll::Ready(Err(super::js_value_to_io_error(err))),
+                    Err(err) => return Poll::Ready(Err(err)),
                 };
                 let read_result: crate::sys::ReadableStreamByobReaderValue = read_result.into();
 
@@ -73,7 +115,7 @@ impl tokio::io::AsyncRead for Reader {
                     already_read: 0,
                 };
 
-                self.poll_read(cx, buf)
+                self.poll_read_js(cx, buf)
             }
             Op::ConsumingReadBuffer {
                 ref mut read_buffer,
@@ -99,38 +141,52 @@ impl tokio::io::AsyncRead for Reader {
                     // under the hood - despite it being an entirely new JS object.
                     // We now have to assume the ownership of the buffer and
                     // properly keep for the next time.
-                    self.internal_buf = Some(read_buffer.buffer());
+                    if is_byob {
+                        self.internal_buf = Some(read_buffer.buffer());
+                    }
                     self.op = Op::Idle;
                     Poll::Ready(Ok(()))
                 } else {
                     self.op = Op::ConsumingReadBuffer {
                         read_buffer: read_buffer.clone(),
-                        already_read: copy_size,
+                        already_read: already_read + copy_size,
                     };
                     Poll::Ready(Ok(()))
                 }
             }
             Op::Idle => {
-                let requested_size = buf.capacity().try_into().unwrap();
-                let internal_buf = self
-                    .internal_buf
-                    .take()
-                    .filter(|internal_buf| {
-                        let actual_size = internal_buf.byte_length();
-                        debug_assert!(actual_size > 0);
-                        actual_size >= requested_size
-                    })
-                    .unwrap_or_else(|| js_sys::ArrayBuffer::new(requested_size));
-                let internal_buf_view = js_sys::Uint8Array::new(&internal_buf);
-                // Despite this not being properly indicated at the type system,
-                // the `read_with_array_buffer_view` fn is actually supposed
-                // to be taking the buffer by value - as it takes the ownership of
-                // the buffer and the old JS reference to it is no longer valid.
-                let fut =
-                    JsFuture::from(self.inner.read_with_array_buffer_view(&internal_buf_view));
+                let fut = match self.inner.clone() {
+                    ReadableStreamReader::Byob(reader) => {
+                        let requested_size = buf.remaining().try_into().unwrap();
+                        let internal_buf = self
+                            .internal_buf
+                            .take()
+                            .filter(|internal_buf| {
+                                let actual_size = internal_buf.byte_length();
+                                debug_assert!(actual_size > 0);
+                                actual_size >= requested_size
+                            })
+                            .unwrap_or_else(|| js_sys::ArrayBuffer::new(requested_size));
+                        let internal_buf_view = js_sys::Uint8Array::new(&internal_buf);
+                        // BYOB reads transfer ownership of the supplied buffer.
+                        JsFuture::from(reader.read_with_array_buffer_view(&internal_buf_view))
+                    }
+                    ReadableStreamReader::Default(reader) => JsFuture::from(reader.read()),
+                };
                 self.op = Op::ReadPending(fut);
-                self.poll_read(cx, buf)
+                self.poll_read_js(cx, buf)
             }
         }
+    }
+}
+
+impl tokio::io::AsyncRead for Reader {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        self.poll_read_js(cx, buf)
+            .map(|result| result.map_err(super::js_value_to_io_error))
     }
 }

--- a/crates/web-sys-stream-utils/src/lib.rs
+++ b/crates/web-sys-stream-utils/src/lib.rs
@@ -3,6 +3,8 @@
 #![cfg(target_family = "wasm")]
 #![allow(missing_docs, clippy::missing_docs_in_private_items)]
 
+use wasm_bindgen::JsCast;
+
 pub mod sys;
 
 pub fn get_reader(
@@ -16,11 +18,22 @@ pub fn get_reader(
 pub fn get_reader_byob(
     readable_stream: impl Into<web_sys::ReadableStream>,
 ) -> web_sys::ReadableStreamByobReader {
+    try_get_reader_byob(readable_stream).unwrap()
+}
+
+pub fn try_get_reader_byob(
+    readable_stream: impl Into<web_sys::ReadableStream>,
+) -> Result<web_sys::ReadableStreamByobReader, wasm_bindgen::JsValue> {
     let readable_stream = readable_stream.into();
     let options = web_sys::ReadableStreamGetReaderOptions::new();
     options.set_mode(web_sys::ReadableStreamReaderMode::Byob);
-    let reader: wasm_bindgen::JsValue = readable_stream.get_reader_with_options(&options).into();
-    reader.into()
+    let get_reader = js_sys::Reflect::get(
+        readable_stream.as_ref(),
+        &wasm_bindgen::JsValue::from_str("getReader"),
+    )?;
+    let get_reader: js_sys::Function = get_reader.dyn_into()?;
+    let reader = get_reader.call1(readable_stream.as_ref(), options.as_ref())?;
+    Ok(reader.into())
 }
 
 pub fn get_writer(
@@ -32,6 +45,12 @@ pub fn get_writer(
 pub async fn read(
     reader: &web_sys::ReadableStreamDefaultReader,
 ) -> Result<Option<Vec<u8>>, wasm_bindgen::JsValue> {
+    Ok(read_array(reader).await?.map(|buf| buf.to_vec()))
+}
+
+pub async fn read_array(
+    reader: &web_sys::ReadableStreamDefaultReader,
+) -> Result<Option<js_sys::Uint8Array>, wasm_bindgen::JsValue> {
     let fut = wasm_bindgen_futures::JsFuture::from(reader.read());
     let result = fut.await?;
     let result: crate::sys::ReadableStreamDefaultReaderValue = result.into();
@@ -44,7 +63,7 @@ pub async fn read(
         unreachable!("no value and we are also not done, this should be impossible");
     };
 
-    Ok(Some(js_buf.to_vec()))
+    Ok(Some(js_buf))
 }
 
 pub async fn read_byob(

--- a/crates/xwt-web/src/lib.rs
+++ b/crates/xwt-web/src/lib.rs
@@ -8,7 +8,7 @@
 )]
 #![cfg(target_family = "wasm")]
 
-use std::{num::NonZeroUsize, rc::Rc};
+use std::{cell::Cell, num::NonZeroUsize, rc::Rc};
 
 use wasm_bindgen::prelude::*;
 
@@ -74,6 +74,9 @@ pub struct Session {
     /// The datagrams state for this session.
     pub datagrams: Datagrams,
 
+    /// Whether this session must use default readable stream readers.
+    use_default_readers: Rc<Cell<bool>>,
+
     /// Whether to close the session on drop.
     pub close_on_drop: bool,
 }
@@ -81,10 +84,12 @@ pub struct Session {
 impl Session {
     /// Construct a new session from a [`web_wt_sys::WebTransport`].
     pub fn new(transport: web_wt_sys::WebTransport) -> Self {
-        let datagrams = Datagrams::from_transport(&transport);
+        let use_default_readers = Rc::new(Cell::new(false));
+        let datagrams = Datagrams::from_transport_with_fallback(&transport, &use_default_readers);
         Self {
             transport: Some(Rc::new(transport)),
             datagrams,
+            use_default_readers,
             close_on_drop: true,
         }
     }
@@ -141,7 +146,7 @@ impl Drop for Session {
 #[derive(Debug)]
 pub struct Datagrams {
     /// The datagram reader.
-    pub readable_stream_reader: web_sys::ReadableStreamByobReader,
+    pub readable_stream_reader: DatagramReader,
 
     /// The datagram writer.
     pub writable_stream_writer: web_sys::WritableStreamDefaultWriter,
@@ -157,6 +162,25 @@ pub struct Datagrams {
     pub unlock_streams_on_drop: bool,
 }
 
+/// A reader for incoming WebTransport datagrams.
+#[derive(Debug)]
+pub enum DatagramReader {
+    /// A bring-your-own-buffer reader.
+    Byob(web_sys::ReadableStreamByobReader),
+    /// A default reader, used when BYOB readers are unsupported.
+    Default(web_sys::ReadableStreamDefaultReader),
+}
+
+impl DatagramReader {
+    /// Release this reader's lock on its stream.
+    fn release_lock(&self) {
+        match self {
+            Self::Byob(reader) => reader.release_lock(),
+            Self::Default(reader) => reader.release_lock(),
+        }
+    }
+}
+
 impl Datagrams {
     /// Create a datagrams state from the transport.
     pub fn from_transport(transport: &web_wt_sys::WebTransport) -> Self {
@@ -167,9 +191,36 @@ impl Datagrams {
     pub fn from_transport_datagrams(
         datagrams: &web_wt_sys::WebTransportDatagramDuplexStream,
     ) -> Self {
+        Self::from_transport_datagrams_with_fallback(datagrams, &Cell::new(false))
+    }
+
+    /// Create datagram state while sharing a session's reader fallback state.
+    fn from_transport_with_fallback(
+        transport: &web_wt_sys::WebTransport,
+        use_default_readers: &Cell<bool>,
+    ) -> Self {
+        Self::from_transport_datagrams_with_fallback(&transport.datagrams(), use_default_readers)
+    }
+
+    /// Create datagram state, falling back when BYOB acquisition fails.
+    fn from_transport_datagrams_with_fallback(
+        datagrams: &web_wt_sys::WebTransportDatagramDuplexStream,
+        use_default_readers: &Cell<bool>,
+    ) -> Self {
         let read_buffer_size = 65536; // 65k buffers as per spec recommendation
 
-        let readable_stream_reader = web_sys_stream_utils::get_reader_byob(datagrams.readable());
+        let readable = datagrams.readable();
+        let readable_stream_reader = if use_default_readers.get() {
+            DatagramReader::Default(web_sys_stream_utils::get_reader(readable))
+        } else {
+            match web_sys_stream_utils::try_get_reader_byob(readable.clone()) {
+                Ok(reader) => DatagramReader::Byob(reader),
+                Err(_) => {
+                    use_default_readers.set(true);
+                    DatagramReader::Default(web_sys_stream_utils::get_reader(readable))
+                }
+            }
+        };
         let writable_stream_writer = web_sys_stream_utils::get_writer(datagrams.writable());
 
         let read_buffer = js_sys::ArrayBuffer::new(read_buffer_size);
@@ -252,11 +303,20 @@ impl Drop for RecvStream {
 fn wrap_recv_stream(
     transport: &Rc<web_wt_sys::WebTransport>,
     stream: web_wt_sys::WebTransportReceiveStream,
+    use_default_readers: &Cell<bool>,
 ) -> RecvStream {
-    let reader = web_sys_stream_utils::get_reader_byob(stream.clone());
-    let reader: JsValue = reader.into();
-    let reader = reader.into();
-    let reader = web_sys_async_io::Reader::new(reader);
+    let readable: web_sys::ReadableStream = stream.clone().into();
+    let reader = if use_default_readers.get() {
+        web_sys_async_io::Reader::new_default(web_sys_stream_utils::get_reader(readable))
+    } else {
+        match web_sys_stream_utils::try_get_reader_byob(readable.clone()) {
+            Ok(reader) => web_sys_async_io::Reader::new(reader),
+            Err(_) => {
+                use_default_readers.set(true);
+                web_sys_async_io::Reader::new_default(web_sys_stream_utils::get_reader(readable))
+            }
+        }
+    };
 
     RecvStream {
         transport: Rc::clone(transport),
@@ -285,12 +345,13 @@ fn wrap_send_stream(
 fn wrap_bi_stream(
     transport: &Rc<web_wt_sys::WebTransport>,
     stream: web_wt_sys::WebTransportBidirectionalStream,
+    use_default_readers: &Cell<bool>,
 ) -> (SendStream, RecvStream) {
     let writeable = stream.writable();
     let readable = stream.readable();
 
     let send_stream = wrap_send_stream(transport, writeable);
-    let recv_stream = wrap_recv_stream(transport, readable);
+    let recv_stream = wrap_recv_stream(transport, readable, use_default_readers);
 
     (send_stream, recv_stream)
 }
@@ -303,7 +364,7 @@ impl xwt_core::session::stream::OpenBi for Session {
     async fn open_bi(&self) -> Result<Self::Opening, Self::Error> {
         let transport = self.transport_ref();
         let value = transport.create_bidirectional_stream().await?;
-        let value = wrap_bi_stream(transport, value);
+        let value = wrap_bi_stream(transport, value, &self.use_default_readers);
         Ok(xwt_core::utils::dummy::OpeningBiStream(value))
     }
 }
@@ -322,7 +383,7 @@ impl xwt_core::session::stream::AcceptBi for Session {
             return Err(Error(JsError::new("xwt: accept bi reader is done").into()));
         }
         let value: web_wt_sys::WebTransportBidirectionalStream = read_result.get_value().into();
-        let value = wrap_bi_stream(transport, value);
+        let value = wrap_bi_stream(transport, value, &self.use_default_readers);
         Ok(value)
     }
 }
@@ -353,7 +414,7 @@ impl xwt_core::session::stream::AcceptUni for Session {
             return Err(Error(JsError::new("xwt: accept uni reader is done").into()));
         }
         let value: web_wt_sys::WebTransportReceiveStream = read_result.get_value().into();
-        let recv_stream = wrap_recv_stream(transport, value);
+        let recv_stream = wrap_recv_stream(transport, value, &self.use_default_readers);
         Ok(recv_stream)
     }
 }
@@ -506,39 +567,19 @@ impl xwt_core::stream::Read for RecvStream {
     type Error = StreamReadError;
 
     async fn read(&mut self, buf: &mut [u8]) -> Result<NonZeroUsize, Self::Error> {
-        let requested_size = buf.len().try_into().unwrap();
-        let internal_buf = self
-            .reader
-            .internal_buf
-            .take()
-            .filter(|internal_buf| {
-                let actual_size = internal_buf.byte_length();
-                debug_assert!(actual_size > 0);
-                actual_size >= requested_size
-            })
-            .unwrap_or_else(|| js_sys::ArrayBuffer::new(requested_size));
-        let internal_buf_view =
-            js_sys::Uint8Array::new_with_byte_offset_and_length(&internal_buf, 0, requested_size);
-        let maybe_internal_buf_view =
-            web_sys_stream_utils::read_byob(&self.reader.inner, internal_buf_view)
-                .await
-                .map_err(|err| StreamReadError::Read(err.into()))?;
-        let Some(internal_buf_view) = maybe_internal_buf_view else {
-            return Err(StreamReadError::ByobReadConsumedBuffer);
-        };
-
-        // Unwrap is safe assuming the `usize` is `u32` in wasm.
-        let len = internal_buf_view.byte_length().try_into().unwrap();
+        let mut read_buf = tokio::io::ReadBuf::new(buf);
+        std::future::poll_fn(|cx| {
+            std::pin::Pin::new(&mut self.reader).poll_read_js(cx, &mut read_buf)
+        })
+        .await
+        .map_err(|error| StreamReadError::Read(error.into()))?;
+        let len = read_buf.filled().len();
 
         // Detect when the read is aborted because the stream was closed without
         // an error.
         let Some(len) = NonZeroUsize::new(len) else {
             return Err(StreamReadError::Closed);
         };
-
-        internal_buf_view.copy_to(&mut buf[..len.get()]);
-
-        self.reader.internal_buf = Some(internal_buf_view.buffer());
 
         Ok(len)
     }
@@ -607,15 +648,29 @@ impl Datagrams {
             js_sys::Uint8Array::new(&buffer)
         };
 
-        let maybe_view =
-            web_sys_stream_utils::read_byob(&self.readable_stream_reader, view).await?;
+        let maybe_view = match &self.readable_stream_reader {
+            DatagramReader::Byob(reader) => web_sys_stream_utils::read_byob(reader, view).await?,
+            DatagramReader::Default(reader) => {
+                let maybe_view = web_sys_stream_utils::read_array(reader).await?;
+                maybe_view.map(|view| {
+                    max_read_size
+                        .filter(|max_read_size| view.length() > *max_read_size)
+                        .map_or(view.clone(), |max_read_size| {
+                            view.subarray(0, max_read_size)
+                        })
+                })
+            }
+        };
         let Some(mut view) = maybe_view else {
             return Err(wasm_bindgen::JsError::new("unexpected stream termination").into());
         };
 
         let result = f(&mut view);
 
-        *buffer_guard = Some(view.buffer());
+        *buffer_guard = Some(match self.readable_stream_reader {
+            DatagramReader::Byob(_) => view.buffer(),
+            DatagramReader::Default(_) => buffer,
+        });
         Ok(result)
     }
 }


### PR DESCRIPTION
Initial draft to fix #229 

Adds an enum over Reader variants. Generic approach was considered, but it would also make all structs which include the reader have to be generic, which sounds like a lot of added complexity for such a simple change. Another approach would be dynamic dispatch, but would require more boilerplate.

```rust
pub enum DatagramReader {
    /// A bring-your-own-buffer reader.
    Byob(web_sys::ReadableStreamByobReader),
    /// A default reader, used when BYOB readers are unsupported.
    Default(web_sys::ReadableStreamDefaultReader),
}
```

I've added some comments where there are behavior changes on the Byob path.