### PR TITLE
Support Safari datagram writable streams

### DIFF
--- a/crates/web-sys-stream-utils/src/lib.rs
+++ b/crates/web-sys-stream-utils/src/lib.rs
@@ -23,10 +23,10 @@ pub fn get_reader_byob(
     reader.into()
 }
 
-pub fn get_writer(
+pub fn try_get_writer(
     writable_stream: web_sys::WritableStream,
-) -> web_sys::WritableStreamDefaultWriter {
-    writable_stream.get_writer().unwrap()
+) -> Result<web_sys::WritableStreamDefaultWriter, wasm_bindgen::JsValue> {
+    writable_stream.get_writer()
 }
 
 pub async fn read(

--- a/crates/web-wt-sys/src/webtransport/web_transport_datagram_duplex_stream.rs
+++ b/crates/web-wt-sys/src/webtransport/web_transport_datagram_duplex_stream.rs
@@ -2,8 +2,9 @@
 //!
 //! <https://w3c.github.io/webtransport/#duplex-stream>
 
-use js_sys::Object;
+use js_sys::{Function, Object, Reflect};
 use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
 use web_sys::{ReadableStream, WritableStream};
 
 #[wasm_bindgen]
@@ -107,6 +108,17 @@ extern "C" {
 }
 
 impl WebTransportDatagramDuplexStream {
+    /// Creates a writable datagram stream using the current standardized API,
+    /// falling back to the older property still exposed by some browsers.
+    pub fn compatible_writable(&self) -> Result<WritableStream, JsValue> {
+        let create_writable = Reflect::get(self.as_ref(), &JsValue::from_str("createWritable"))?;
+        if let Some(create_writable) = create_writable.dyn_ref::<Function>() {
+            return create_writable.call0(self.as_ref())?.dyn_into();
+        }
+
+        Reflect::get(self.as_ref(), &JsValue::from_str("writable"))?.dyn_into()
+    }
+
     crate::set_option_accessors! {
         /// ```webidl
         /// attribute unrestricted double? incomingMaxAge;

--- a/crates/xwt-web/src/lib.rs
+++ b/crates/xwt-web/src/lib.rs
@@ -58,7 +58,7 @@ impl xwt_core::endpoint::connect::Connecting for Connecting {
         let Connecting { transport } = self;
         transport.ready().await?;
 
-        Ok(Session::new(transport))
+        Session::new(transport)
     }
 }
 
@@ -80,13 +80,13 @@ pub struct Session {
 
 impl Session {
     /// Construct a new session from a [`web_wt_sys::WebTransport`].
-    pub fn new(transport: web_wt_sys::WebTransport) -> Self {
-        let datagrams = Datagrams::from_transport(&transport);
-        Self {
+    pub fn new(transport: web_wt_sys::WebTransport) -> Result<Self, Error> {
+        let datagrams = Datagrams::from_transport(&transport)?;
+        Ok(Self {
             transport: Some(Rc::new(transport)),
             datagrams,
             close_on_drop: true,
-        }
+        })
     }
 
     /// If possible, relieves the underlying [`web_wt_sys::WebTransport`] of
@@ -159,29 +159,30 @@ pub struct Datagrams {
 
 impl Datagrams {
     /// Create a datagrams state from the transport.
-    pub fn from_transport(transport: &web_wt_sys::WebTransport) -> Self {
+    pub fn from_transport(transport: &web_wt_sys::WebTransport) -> Result<Self, Error> {
         Self::from_transport_datagrams(&transport.datagrams())
     }
 
     /// Create a datagrams state from the transport datagrams.
     pub fn from_transport_datagrams(
         datagrams: &web_wt_sys::WebTransportDatagramDuplexStream,
-    ) -> Self {
+    ) -> Result<Self, Error> {
         let read_buffer_size = 65536; // 65k buffers as per spec recommendation
 
         let readable_stream_reader = web_sys_stream_utils::get_reader_byob(datagrams.readable());
-        let writable_stream_writer = web_sys_stream_utils::get_writer(datagrams.writable());
+        let writable = datagrams.compatible_writable()?;
+        let writable_stream_writer = web_sys_stream_utils::try_get_writer(writable)?;
 
         let read_buffer = js_sys::ArrayBuffer::new(read_buffer_size);
         let read_buffer = tokio::sync::Mutex::new(Some(read_buffer));
 
-        Self {
+        Ok(Self {
             readable_stream_reader,
             writable_stream_writer,
             read_buffer_size,
             read_buffer,
             unlock_streams_on_drop: true,
-        }
+        })
     }
 }
 


### PR DESCRIPTION
Fixes a second Safari incompatibility I found while fixing #229 

Safari only supports the new standard `CreateWriteable()` API, while all other browsers only support the `datagrams.writeable` property.

`datagrams.CreateWriteable()`: https://developer.mozilla.org/en-US/docs/Web/API/WebTransportDatagramDuplexStream/createWritable

`datagrams.writeable`: https://developer.mozilla.org/en-US/docs/Web/API/WebTransportDatagramDuplexStream/writable

